### PR TITLE
v1.4.0: Fix macOS RDP keystrokes and Accessibility prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macro_paste"
-version = "1.3.4"
+version = "1.4.0"
 dependencies = [
  "arboard",
  "core-foundation 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_paste"
-version = "1.3.4"
+version = "1.4.0"
 edition = "2024"
 description = "System tray app that pastes clipboard text as individual keystrokes"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ Keystroke simulation requires Accessibility access. Grant it under:
 
 If the icon does not appear, macOS may be hiding it due to limited menu bar space. Hold `Cmd` and drag other icons to the right to make room, or check whether a menu bar manager (Bartender, Ice, etc.) has hidden it.
 
+**Important – RDP sessions: use Unicode keyboard mode:**
+
+When pasting into a **Windows RDP session** (Microsoft Remote Desktop / Windows App) from macOS, switch the RDP client to **Unicode** keyboard mode:
+
+**Connections → Keyboard Mode → Unicode** (shortcut `⌃⌘U`).
+
+In the default *Scancode* mode the RDP client sends physical key positions and strips synthesized modifier keys, so uppercase letters and special characters (e.g. `ä ö ü`, `:`) arrive wrong or lowercased. Unicode mode forwards the actual character and makes all input correct regardless of the keyboard layout. This is a setting in the RDP client, not in macro_paste.
+
 ## Usage
 
 1. **Copy text** – e.g. copy a password to the clipboard with `Ctrl+C` / `Cmd+C`

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Build a local, signed macro_paste.app for development/testing on macOS.
+#
+# Signs with the self-signed "macro_paste-dev" identity so the Accessibility
+# (TCC) permission survives rebuilds — macOS keys the permission on the
+# signature's Designated Requirement (stable cert + bundle id), not on the
+# binary hash. Grant Accessibility once; subsequent rebuilds keep working.
+#
+# Create the identity once (see README / one-time setup) if it is missing.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+IDENTITY="macro_paste-dev"
+APP="target/release/macro_paste.app"
+
+if ! security find-identity -p codesigning | grep -q "$IDENTITY"; then
+    echo "error: code-signing identity '$IDENTITY' not found in keychain." >&2
+    echo "       Run the one-time identity setup first (see scripts/setup-signing.sh)." >&2
+    exit 1
+fi
+
+echo "==> Building release binary"
+cargo build --release
+
+echo "==> Assembling app bundle"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+cp target/release/macro_paste "$APP/Contents/MacOS/macro_paste"
+cp assets/Info.plist "$APP/Contents/Info.plist"
+cp assets/macro_paste.icns "$APP/Contents/Resources/macro_paste.icns"
+
+echo "==> Signing with '$IDENTITY'"
+codesign --force --deep --sign "$IDENTITY" "$APP"
+codesign --verify --verbose=2 "$APP"
+
+echo "==> Done: $APP"
+echo "    Launch with: open $APP"

--- a/scripts/setup-signing.sh
+++ b/scripts/setup-signing.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# One-time setup: create a self-signed "macro_paste-dev" code-signing identity
+# in the login keychain. This lets local dev builds be signed with a stable
+# identity so the macOS Accessibility (TCC) permission survives rebuilds.
+#
+# Safe to re-run: it skips creation if the identity already exists.
+
+set -euo pipefail
+
+IDENTITY="macro_paste-dev"
+
+if security find-identity -p codesigning | grep -q "$IDENTITY"; then
+    echo "Identity '$IDENTITY' already exists – nothing to do."
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/cert.conf" <<'EOF'
+[ req ]
+distinguished_name = req_dn
+x509_extensions = v3_codesign
+prompt = no
+[ req_dn ]
+CN = macro_paste-dev
+[ v3_codesign ]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+EOF
+
+echo "==> Generating key + self-signed code-signing certificate"
+openssl req -x509 -newkey rsa:2048 \
+    -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
+    -days 3650 -nodes -config "$TMP/cert.conf" 2>/dev/null
+
+echo "==> Packaging as PKCS#12 (legacy algorithms for macOS compatibility)"
+openssl pkcs12 -export -legacy \
+    -inkey "$TMP/key.pem" -in "$TMP/cert.pem" \
+    -out "$TMP/id.p12" -passout pass:temp -name "$IDENTITY"
+
+echo "==> Importing into login keychain (allowing codesign to use the key)"
+security import "$TMP/id.p12" \
+    -k ~/Library/Keychains/login.keychain-db \
+    -P temp -T /usr/bin/codesign
+
+echo "==> Done. Identity '$IDENTITY' created."
+echo "    The certificate is self-signed and not trusted as a root; that is fine —"
+echo "    codesign uses it for signing and TCC keys on the Designated Requirement."

--- a/src/keystrokes/macos.rs
+++ b/src/keystrokes/macos.rs
@@ -4,7 +4,12 @@
 //! to simulate key presses. Requires Accessibility permission
 //! (System Settings > Privacy & Security > Accessibility).
 
-use core_graphics::event::{CGEvent, CGEventTapLocation};
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use core_foundation::string::CFStringRef;
+use core_graphics::event::{CGEvent, CGEventFlags, CGEventTapLocation};
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 
 /// Wait until all modifier keys (Cmd, Shift, Ctrl, Option) are released,
@@ -47,8 +52,160 @@ pub fn wait_for_modifiers_released() {
     std::thread::sleep(std::time::Duration::from_millis(50));
 }
 
+// --- Carbon / HIToolbox FFI for keyboard-layout-aware character mapping ---
+#[link(name = "Carbon", kind = "framework")]
+unsafe extern "C" {
+    static kTISPropertyUnicodeKeyLayoutData: CFStringRef;
+
+    fn TISCopyCurrentKeyboardLayoutInputSource() -> *mut c_void;
+    fn TISGetInputSourceProperty(source: *mut c_void, key: CFStringRef) -> *mut c_void;
+    fn LMGetKbdType() -> u8;
+
+    #[allow(clippy::too_many_arguments)]
+    fn UCKeyTranslate(
+        keyLayoutPtr: *const u8,
+        virtualKeyCode: u16,
+        keyAction: u16,
+        modifierKeyState: u32,
+        keyboardType: u32,
+        keyTranslateOptions: u32,
+        deadKeyState: *mut u32,
+        maxStringLength: usize,
+        actualStringLength: *mut usize,
+        unicodeString: *mut u16,
+    ) -> i32;
+}
+
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFDataGetBytePtr(data: *const c_void) -> *const u8;
+    fn CFRelease(cf: *const c_void);
+}
+
+/// A character's keystroke representation: the physical virtual key code plus
+/// the modifier flags (Shift / Option) required to produce it on the current
+/// keyboard layout.
+#[derive(Clone, Copy)]
+struct KeyStroke {
+    keycode: u16,
+    flags: CGEventFlags,
+}
+
+/// Reverse keyboard-layout map: character -> physical keystroke.
+///
+/// Built once from the user's *current* keyboard layout via `UCKeyTranslate`.
+/// This is what lets remote desktop clients (RDP, VNC, VMs) receive the correct
+/// key. Those clients ignore the Unicode payload of a synthetic event and read
+/// the hardware key code instead — without a real key code, keycode 0 maps to
+/// "a", so every character would arrive as "aaaa…".
+fn keymap() -> &'static HashMap<char, KeyStroke> {
+    static MAP: OnceLock<HashMap<char, KeyStroke>> = OnceLock::new();
+    MAP.get_or_init(build_keymap)
+}
+
+fn build_keymap() -> HashMap<char, KeyStroke> {
+    const KEY_ACTION_DOWN: u16 = 0;
+    // modifierKeyState passed to UCKeyTranslate is (Carbon event modifiers >> 8).
+    // shiftKey (1 << 9) >> 8 = 2, optionKey (1 << 11) >> 8 = 8.
+    const MOD_COMBOS: &[(u32, CGEventFlags)] = &[
+        (0, CGEventFlags::CGEventFlagNull),
+        (2, CGEventFlags::CGEventFlagShift),
+        (8, CGEventFlags::CGEventFlagAlternate),
+        (
+            10,
+            CGEventFlags::from_bits_truncate(
+                CGEventFlags::CGEventFlagShift.bits() | CGEventFlags::CGEventFlagAlternate.bits(),
+            ),
+        ),
+    ];
+
+    let mut map: HashMap<char, KeyStroke> = HashMap::new();
+
+    unsafe {
+        let source = TISCopyCurrentKeyboardLayoutInputSource();
+        if source.is_null() {
+            return map;
+        }
+
+        let layout_data = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData);
+        if layout_data.is_null() {
+            CFRelease(source);
+            return map;
+        }
+
+        let layout_ptr = CFDataGetBytePtr(layout_data);
+        let kbd_type = LMGetKbdType() as u32;
+
+        // Iterate every physical key with each modifier combination and record
+        // which character it produces. First (simplest) combo wins per char.
+        for keycode in 0u16..128 {
+            for &( uc_mods, cg_flags) in MOD_COMBOS {
+                let mut dead_key_state: u32 = 0;
+                let mut buf = [0u16; 8];
+                let mut len: usize = 0;
+
+                let status = UCKeyTranslate(
+                    layout_ptr,
+                    keycode,
+                    KEY_ACTION_DOWN,
+                    uc_mods,
+                    kbd_type,
+                    0, // kUCKeyTranslateNoDeadKeysBit not set; resolve dead keys
+                    &mut dead_key_state,
+                    buf.len(),
+                    &mut len,
+                    buf.as_mut_ptr(),
+                );
+
+                if status != 0 || len == 0 {
+                    continue;
+                }
+
+                if let Some(ch) = String::from_utf16_lossy(&buf[..len]).chars().next() {
+                    // Skip control characters; those are handled as special keys.
+                    if ch.is_control() {
+                        continue;
+                    }
+                    map.entry(ch).or_insert(KeyStroke {
+                        keycode,
+                        flags: cg_flags,
+                    });
+                }
+            }
+        }
+
+        CFRelease(source);
+    }
+
+    map
+}
+
+/// Returns true if this process is trusted for Accessibility (the permission
+/// required to synthesize keyboard input). macOS silently drops posted key
+/// events when this is false, so we check it to give the user feedback.
+pub fn is_accessibility_trusted() -> bool {
+    #[link(name = "ApplicationServices", kind = "framework")]
+    unsafe extern "C" {
+        fn AXIsProcessTrusted() -> bool;
+    }
+    unsafe { AXIsProcessTrusted() }
+}
+
 /// Send a single Unicode character as a keystroke via CGEvent.
-/// Silently fails if permissions are missing or event creation fails.
+///
+/// Sets the Unicode string on the event — the primary path: native macOS apps
+/// and remote desktop clients in *Unicode* keyboard mode read this, so every
+/// character (uppercase, umlauts, symbols) is delivered correctly regardless of
+/// keyboard layout. Additionally sets a best-effort physical key code +
+/// modifier flags from the current layout, so remote desktop clients in
+/// *scancode* mode still produce the right key instead of mapping the
+/// placeholder key code 0 to "a".
+///
+/// Note: in scancode mode RDP strips synthesized modifier state, so
+/// Shift-dependent characters cannot be produced reliably there. Switch the RDP
+/// client to Unicode keyboard mode (Connections → Keyboard Mode → Unicode) for
+/// fully correct input — see README. Silently fails if permissions are missing
+/// or event creation fails.
 pub fn send_unicode_char(ch: char) {
     let source = match CGEventSource::new(CGEventSourceStateID::HIDSystemState) {
         Ok(s) => s,
@@ -58,20 +215,46 @@ pub fn send_unicode_char(ch: char) {
         }
     };
 
-    // Create a dummy key event (keycode 0), then override with Unicode string
-    if let Ok(event) = CGEvent::new_keyboard_event(source.clone(), 0, true) {
-        // Set the Unicode character on the event
-        let mut utf16_buf = [0u16; 2];
-        let utf16_units = ch.encode_utf16(&mut utf16_buf);
-        event.set_string_from_utf16_unchecked(utf16_units);
+    // Best-effort physical key for this character on the current layout; falls
+    // back to key code 0 (Unicode-only) for characters with no direct key.
+    let stroke = keymap().get(&ch).copied();
+    let keycode = stroke.map(|s| s.keycode).unwrap_or(0);
+    let flags = stroke
+        .map(|s| s.flags)
+        .unwrap_or(CGEventFlags::CGEventFlagNull);
 
-        // Post key down
+    let mut utf16_buf = [0u16; 2];
+    let utf16_units = ch.encode_utf16(&mut utf16_buf);
+
+    if let Ok(event) = CGEvent::new_keyboard_event(source.clone(), keycode, true) {
+        event.set_flags(flags);
+        event.set_string_from_utf16_unchecked(utf16_units);
         event.post(CGEventTapLocation::HID);
 
-        // Post key up
-        if let Ok(up_event) = CGEvent::new_keyboard_event(source, 0, false) {
+        if let Ok(up_event) = CGEvent::new_keyboard_event(source, keycode, false) {
+            up_event.set_flags(flags);
+            up_event.set_string_from_utf16_unchecked(utf16_units);
             up_event.post(CGEventTapLocation::HID);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keymap_builds_and_is_populated() {
+        let map = build_keymap();
+        // A US/DE layout must at least produce lowercase ASCII letters.
+        println!("keymap entries: {}", map.len());
+        for ch in ['a', 'A', '1', '!', '@'] {
+            match map.get(&ch) {
+                Some(ks) => println!("{ch:?} -> keycode {} flags {:?}", ks.keycode, ks.flags),
+                None => println!("{ch:?} -> (none)"),
+            }
+        }
+        assert!(map.contains_key(&'a'), "keymap should contain 'a'");
     }
 }
 

--- a/src/keystrokes/mod.rs
+++ b/src/keystrokes/mod.rs
@@ -20,6 +20,19 @@ pub fn wait_for_modifiers_released() {
     macos::wait_for_modifiers_released();
 }
 
+/// Returns true if the app has the OS permission required to synthesize input.
+/// On Windows this is always available; on macOS it requires Accessibility trust.
+pub fn has_input_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::is_accessibility_trusted()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
 /// Send a string as individual keystrokes with the given delay between each character.
 /// Delegates to the platform-specific implementation for the actual key simulation.
 pub fn send_string_as_keystrokes(text: &str, delay_ms: u64) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,13 @@ impl App {
     /// Execute the paste-as-keystrokes action: read clipboard and type it out.
     /// Runs in a background thread to avoid blocking the event loop.
     fn do_paste(&self) {
+        // Without the OS input permission, posted key events are silently
+        // dropped. Tell the user and point them to the settings instead.
+        if !keystrokes::has_input_permission() {
+            notify::prompt_missing_permission();
+            return;
+        }
+
         let delay_ms = self.config.delay_ms;
 
         if let Some(text) = clipboard::get_clipboard_text() {
@@ -238,6 +245,12 @@ impl ApplicationHandler for App {
         if actual_autostart != cfg.autostart {
             self.config.autostart = actual_autostart;
             let _ = self.config.save();
+        }
+
+        // Warn early if the input permission is missing, so the user can fix it
+        // before the first paste instead of hitting a silent no-op.
+        if !keystrokes::has_input_permission() {
+            notify::prompt_missing_permission();
         }
     }
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,5 +1,51 @@
 //! Simple cross-platform error notification via native message boxes.
 
+/// Inform the user that the required input permission is missing and offer to
+/// open the relevant system settings. macOS only (Accessibility); no-op
+/// elsewhere. Runs in a background thread so the modal dialog never blocks the
+/// event loop, and de-duplicates so repeated paste attempts don't stack dialogs.
+pub fn prompt_missing_permission() {
+    #[cfg(target_os = "macos")]
+    {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static PROMPT_OPEN: AtomicBool = AtomicBool::new(false);
+
+        // Skip if a prompt is already on screen.
+        if PROMPT_OPEN.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        std::thread::spawn(|| {
+            use std::process::Command;
+
+            const OPEN_BTN: &str = "Einstellungen öffnen";
+            let script = format!(
+                "display dialog \"macro_paste benötigt die Berechtigung »Bedienungshilfen«, \
+                 um Tastatureingaben zu senden.\\n\\nBitte aktiviere macro_paste unter:\\n\
+                 Systemeinstellungen → Datenschutz & Sicherheit → Bedienungshilfen.\" \
+                 with title \"Berechtigung erforderlich\" \
+                 buttons {{\"Später\", \"{OPEN_BTN}\"}} default button \"{OPEN_BTN}\" \
+                 with icon caution"
+            );
+
+            let clicked_open = Command::new("osascript")
+                .arg("-e")
+                .arg(&script)
+                .output()
+                .map(|out| String::from_utf8_lossy(&out.stdout).contains(OPEN_BTN))
+                .unwrap_or(false);
+
+            if clicked_open {
+                let _ = Command::new("open")
+                    .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+                    .spawn();
+            }
+
+            PROMPT_OPEN.store(false, Ordering::SeqCst);
+        });
+    }
+}
+
 /// Show an error message to the user via a native message box.
 /// Also logs to stderr as a fallback.
 pub fn show_error(title: &str, message: &str) {

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -76,6 +76,17 @@ pub fn build_tray(
     // Assemble the full menu
     let menu = Menu::new();
     menu.append(&version_item).map_err(|e| e.to_string())?;
+    // macOS RDP hint (disabled, informational): RDP strips synthesized modifier
+    // keys in scancode mode, so uppercase/special chars need Unicode mode.
+    #[cfg(target_os = "macos")]
+    {
+        let rdp_hint = tray_icon::menu::MenuItem::new(
+            "RDP tip: Keyboard Mode → Unicode (⌃⌘U)",
+            false,
+            None,
+        );
+        menu.append(&rdp_hint).map_err(|e| e.to_string())?;
+    }
     menu.append(&PredefinedMenuItem::separator()).map_err(|e| e.to_string())?;
     menu.append(&paste_now).map_err(|e| e.to_string())?;
     menu.append(&PredefinedMenuItem::separator()).map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary

Fixes macOS keystroke simulation in remote desktop (RDP) sessions and adds feedback when the Accessibility permission is missing.

## Keystrokes — `Closes #5`

Previously every character was sent with virtual **key code 0** and only a Unicode payload. RDP ignores the Unicode payload and reads the hardware key code — and key code 0 is `kVK_ANSI_A` = "a", so all input arrived as `aaaa…`.

- Map each character to a **real virtual key code + modifier flags** from the current keyboard layout via `UCKeyTranslate` (reverse lookup built once).
- Keep the **Unicode string** on every event as the primary path: native apps and RDP in **Unicode keyboard mode** read it, so all characters (uppercase, umlauts, symbols) are delivered correctly regardless of layout.
- Document that RDP must use **Unicode keyboard mode** (`Connections → Keyboard Mode → Unicode`, `⌃⌘U`) for fully correct input. In scancode mode RDP strips synthesized modifier state and cannot produce Shift-dependent characters reliably — this is a client limitation, not fixable from the sender side. Added a README note and a macOS-only tray hint.

## Accessibility — `Closes #2`

The app failed silently when the Accessibility permission was missing (macOS revokes it whenever the binary changes).

- Detect missing permission via `AXIsProcessTrusted()`.
- On startup **and** before each paste, show a native dialog with an **"Einstellungen öffnen"** button that opens the Accessibility settings directly (`x-apple.systempreferences:…Privacy_Accessibility`), instead of doing nothing.

## Tooling

- `scripts/setup-signing.sh` + `scripts/build-mac.sh`: build a locally signed `.app` with a stable self-signed identity, so the Accessibility permission survives rebuilds (ad-hoc/linker-signed binaries change their cdhash each build and lose the grant).

## Version

Bumped to **1.4.0**.

## Testing

- `cargo build` clean, no warnings; keymap unit test passes.
- Verified manually in a Windows RDP session: with Unicode keyboard mode, uppercase, umlauts and symbols arrive correctly. The Accessibility dialog opens and links straight into the settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)