### PR TITLE
v1.4.1: Translate Accessibility permission dialog to English

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "macro_paste"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "arboard",
  "core-foundation 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_paste"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 description = "System tray app that pastes clipboard text as individual keystrokes"
 license = "MIT"

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -18,13 +18,13 @@ pub fn prompt_missing_permission() {
         std::thread::spawn(|| {
             use std::process::Command;
 
-            const OPEN_BTN: &str = "Einstellungen öffnen";
+            const OPEN_BTN: &str = "Open Settings";
             let script = format!(
-                "display dialog \"macro_paste benötigt die Berechtigung »Bedienungshilfen«, \
-                 um Tastatureingaben zu senden.\\n\\nBitte aktiviere macro_paste unter:\\n\
-                 Systemeinstellungen → Datenschutz & Sicherheit → Bedienungshilfen.\" \
-                 with title \"Berechtigung erforderlich\" \
-                 buttons {{\"Später\", \"{OPEN_BTN}\"}} default button \"{OPEN_BTN}\" \
+                "display dialog \"macro_paste needs the Accessibility permission \
+                 to send keystrokes.\\n\\nPlease enable macro_paste under:\\n\
+                 System Settings → Privacy & Security → Accessibility.\" \
+                 with title \"Permission required\" \
+                 buttons {{\"Later\", \"{OPEN_BTN}\"}} default button \"{OPEN_BTN}\" \
                  with icon caution"
             );
 


### PR DESCRIPTION
## Summary

The dialog shown when the macOS Accessibility permission is missing was in German. This translates it to English.

- Title: `Permission required`
- Body: `macro_paste needs the Accessibility permission to send keystrokes. …`
- Buttons: `Later` / `Open Settings`
- Updated the button-detection string in `prompt_missing_permission()` to match the new `Open Settings` label, so the button still opens the Accessibility settings.

Version bumped to **1.4.1**.

`Closes #7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)